### PR TITLE
HOTFIX: npm 배포 파이프라인 개선

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,46 +2,96 @@ name: Publish to npm
 
 on:
   pull_request:
+    # PR 이벤트 중 closed 일 때만 트리거
     types:
       - closed
+    # PR의 타깃 브랜치가 main일 때만 동작
     branches:
       - main
 
 jobs:
   publish:
+    # closed > merged branch  일 때만 동작
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+
     steps:
+      # Repository 체크아웃.
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Repository의 (커밋, 태그) 이력을 모두 가져온다.
+          fetch-depth: 0
 
+      # Node.js 환경 세팅.
+      # npm registry를 공식 레지스트리로 지정.
+      # (setup-node가 .npmrc를 잡아줘서 이후 npm publish 시 토큰 사용 가능)
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org/'
 
+      # 의존성 설치.
+      # lockfile 불일치 시 실패하도록 고정.
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # (브랜치명에서) 버전 추출.
+      # - 허용 형태: 'root/x.y.z'로 시작하는 모든 브랜치 ( ex) root/1.2.3-alpha )
+      # - 매칭 실패 시 'skip=true' 출력하고 정상 종료(exit 0)해서 이후 스텝들이 조건문으로 스킵되게 함.
       - name: Extract version from branch name
         id: version
         run: |
           BRANCH_NAME="${GITHUB_HEAD_REF}"
-          VERSION=$(echo "$BRANCH_NAME" | sed -n 's/^root\/\([0-9]*\.[0-9]*\.[0-9]*\)$/\1/p')
+          VERSION=$(echo "$BRANCH_NAME" | sed -n 's/^root\/\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/p')
           if [ -z "$VERSION" ]; then
-            echo "Branch name does not match version pattern (root/x.x.x)"
-            exit 1
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Update version
-        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+      # git identity 설정 (commit, tag push 시 필요)
+      - name: Setup git identity
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # package.json 버전 갱신 + git 태그 생성
+      - name: Update version
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          npm version ${{ steps.version.outputs.version }} -m "CHORE: (release) %s"
+
+      # 버전 커밋 + 태그 push
+      - name: Push version commit and tag
+        if: steps.version.outputs.skip != 'true'
+        run: git push origin main --follow-tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # 빌드.
       - name: Build
+        if: steps.version.outputs.skip != 'true'
         run: yarn build
 
+      # 배포.
+      # - Github Repository Secret 에 환경변수(NPM_TOKEN)가 설정되어 있어야 함.
+      # - package.json에 "name"과 "version" 정상 지정.
+      # - private: true면 publish 불가.
+      # - 스코프 패키지(@scope/name)를 public로 배포하려면 --access public 필요.
       - name: Publish
+        if: steps.version.outputs.skip != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
+
+      # GitHub Release 작성.
+      - name: Create GitHub Release
+        if: steps.version.outputs.skip != 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
+          generate_release_notes: true


### PR DESCRIPTION
## AS-IS
- 모든 `main` 머지 시점에서 publish workflow 가 실행된다.
- 브랜치 네이밍 규칙 검증이 없어, 의도치 않은 브랜치에서도 npm publish 시도가 발생한다.
- `npm version` 실행 시 git 태그/커밋 push 과정이 누락되어 Release 자동화가 불완전하다.
- Release note 생성이 없어, 어떤 변경이 배포되었는지 추적하기 어렵다.

<br/>

## TO-BE
- **배포 전용 브랜치**(`root/x.y.z` 형태)와 일반 작업 브랜치를 명확히 구분한다.
- publish workflow 는 브랜치명이 `root/x.y.z`로 시작하는 경우에만 동작한다.
  - 검증 사항: 브랜치명이 `root/`로 시작하고, 뒤에 세 자리 숫자 버전 (`x.y.z`) 패턴이 존재해야 함.
  - 해당 패턴과 일치하지 않는 경우 → `skip=true` 로 처리되어 workflow 는 종료된다.

<br/>

- NPM 배포 시 다음이 이뤄져야 한다.
  - `npm version` 으로 package.json 버전 업데이트 및 git 태그 생성
  - 생성된 버전 커밋 및 태그를 원격 저장소(main)으로 push
  - `yarn build` 로 빌드 실행
  - `npm publish --access public` 으로 패키지 배포
  - GitHub Release 를 생성하고, `generate_release_notes: true` 로 자동 Release note 작성
